### PR TITLE
amended gha workflow to use gh app token to play well with bpr

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          # NOTE: we can't set persist-credentials to false or else ghp-import will fail later
+          persist-credentials: false
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
@@ -34,6 +34,8 @@ jobs:
         run: uv run generate_stats.py
 
       - name: Publish to gh-pages
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           uv tool run ghp-import@2.1.0 \
           --no-jekyll \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,16 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.FPF_BRANCH_UPDATER_APP_ID }}
+          private-key: ${{ secrets.FPF_BRANCH_UPDATER_APP_PRIVKEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # NOTE: we can't set persist-credentials to false or else ghp-import will fail later
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
@@ -26,7 +34,7 @@ jobs:
 
       - name: Publish to gh-pages
         run: |
-          uv tool run ghp-import \
+          uv tool run ghp-import@2.1.0 \
           --no-jekyll \
           --cname stats.dangerzone.rocks \
           --no-history \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
       - uses: actions/create-github-app-token@v2
+        id: app-token
         with:
           app-id: ${{ vars.FPF_BRANCH_UPDATER_APP_ID }}
           private-key: ${{ secrets.FPF_BRANCH_UPDATER_APP_PRIVKEY }}


### PR DESCRIPTION
Changed the GHA to use a minimal, fpf-internal GH app to enable bypassing of branch protections when run.  For details on this application, see [this FPF wiki entry](https://wiki.freedom.press/wiki/FPF_GHA_branch_updater).

One notable change is that I pinned `ghp-import` to what is currently the most recent version to protect against potential token leakage if upstream gets changed maliciously.  They haven't updated in a few years, but if they do, we'll have to remember to update the action too.

Although not made explicit in this PR, I have simultaneously added some branch protections, including:

* A legacy-style BPR on `main` that explicitly restricts push/merge privs to [DZ Maintainers](https://github.com/orgs/freedomofpress/teams/dangerzone-maintainers)
* A ruleset that requires PRs to update `main` (along with some other basic protections), though does not require approvals
* A ruleset that protects `gh-pages` from some basic shenanigans (e.g. can't be deleted)
* A ruleset that only allows the above application or DZ maintainers to direct push or merge to `gh-pages`
  * Note that when changing `gh-pages`, DZ maintainers will get warnings thrown at them (if doing so via API call) or will need to check a scary "bypass protections" box (if doing so via web interface)

Taken together, this means anyone can create a PR targeting `main`, but only DZ Maintainers can merge it.  They can also self-merge without restriction, but do still need to create the PR.  Changes to `gh-pages` do not require PRs, but only the GHA workflow or DZ Maintainers can do so.  Any manual changes will require intention and extra steps.